### PR TITLE
Removed unused form field "label" and added default label to legal optin pp

### DIFF
--- a/src/Resources/skeleton/legal/Entity/PageParts/LegalOptInPagePart.php
+++ b/src/Resources/skeleton/legal/Entity/PageParts/LegalOptInPagePart.php
@@ -93,7 +93,7 @@ class LegalOptInPagePart extends AbstractFormPagePart
     {
         $bfsf = new BooleanFormSubmissionField();
         $bfsf->setFieldName('field_'.$this->getUniqueId());
-        $bfsf->setLabel($this->getLabel());
+        $bfsf->setLabel('Legal opt-in checked');
         $bfsf->setSequence($sequence);
 
         $data = $formBuilder->getData();

--- a/src/Resources/skeleton/legal/Form/PageParts/LegalOptInPagePartAdminType.php
+++ b/src/Resources/skeleton/legal/Form/PageParts/LegalOptInPagePartAdminType.php
@@ -23,14 +23,6 @@ class LegalOptInPagePartAdminType extends AbstractType
     {
         $builder
             ->add(
-                'label',
-                TextType::class,
-                [
-                    'label' => 'kuma_form.form.checkbox_page_part.label.label',
-                    'required' => false,
-                ]
-            )
-            ->add(
                 'required',
                 CheckboxType::class,
                 [


### PR DESCRIPTION
The form field label is not used in the twig template for this field. So removed the label field and added a default value when inserting in the DB.