### PR TITLE
Don't let google index modal pages

### DIFF
--- a/src/Resources/skeleton/legal/DataFixtures/ORM/LegalGenerator/DefaultFixtures.php
+++ b/src/Resources/skeleton/legal/DataFixtures/ORM/LegalGenerator/DefaultFixtures.php
@@ -102,6 +102,8 @@ class DefaultFixtures extends AbstractFixture implements OrderedFixtureInterface
                 'language' => $locale,
                 'callback' => function (LegalFolderPage $page, NodeTranslation $translation, $seo) {
                     $translation->setTitle('Legal');
+
+                    $seo->setMetaRobots('noindex,nofollow');
                 },
             ];
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

Currently google will index the modal pages but when you visit the direct url, you will get an unstyled html page. So don't let google index the legal modal pages