### PR TITLE
Allow only ajax requests to the cookie detail route

### DIFF
--- a/src/Controller/LegalController.php
+++ b/src/Controller/LegalController.php
@@ -57,7 +57,7 @@ class LegalController extends AbstractController
     }
 
     /**
-     * @Route("/detail/{internalName}", name="kunstmaancookiebundle_legal_detail")
+     * @Route("/detail/{internalName}", name="kunstmaancookiebundle_legal_detail", methods={"GET"}, condition="request.isXmlHttpRequest()")
      * @ParamConverter("cookieType", options={"mapping": {"internalName": "internalName"}})
      * @param Request    $request
      * @param CookieType $cookieType


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Google will visit and try to analyze the cookie detail pages (in search console). This will avoid accessing the routes directly and it will only work in the cookie bundle modal