### PR TITLE
Improve scss image vars 

### DIFF
--- a/src/Resources/ui/scss/components/_to-top-button.scss
+++ b/src/Resources/ui/scss/components/_to-top-button.scss
@@ -22,7 +22,7 @@
     transform: translateX(-100%);
 
     background: $kmcc_primary-color;
-    background-image: url(/frontend/img/legal/svg/arrow--up.svg);
+    background-image: url($arrow-up-image);
     background-repeat: no-repeat;
     background-position: 50% 50%;
 

--- a/src/Resources/ui/scss/config/_variables.scss
+++ b/src/Resources/ui/scss/config/_variables.scss
@@ -91,5 +91,7 @@ $kmcc-fact__figure-width:          150px;
 
 /* Fact
    ========================================================================== */
-$toggle-check-image:               "../../frontend/img/legal/svg/toggle--check.svg" !default;
-$toggle-cross-image:               "../../frontend/img/legal/svg/toggle--cross.svg" !default;
+$base-image-path:                  "../../frontend/img/legal/svg/";
+$toggle-check-image:               $base-image-path + "toggle--check.svg" !default;
+$toggle-cross-image:               $base-image-path + "toggle--cross.svg" !default;
+$arrow-up-image:                   $base-image-path + "arrow--up.svg" !default;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Improve the image vars introduced in #21. The base var allows to just override the path without needing to specifically set each image var and I've added a missing var for the arrow up svg.