### PR TITLE
[CookieBundle] Fix issue with template file after sf4 compatibility changes

### DIFF
--- a/src/Resources/skeleton/legal/Resources/views/Pages/LegalPage/pagetemplate.html.twig
+++ b/src/Resources/skeleton/legal/Resources/views/Pages/LegalPage/pagetemplate.html.twig
@@ -25,7 +25,13 @@
         {% for key,tab in tabs %}
             {% if tab is not null %}
                 {% set pageToRender = get_page_by_node_translation(tab.nodeTranslation(app.request.locale, true)) %}
-                {% include 'KunstmaanCookieBundle:Components:TabBarContentPanel.html.twig' with {'key':key, 'tab':tab, 'page': pageToRender, 'bundle':'<%= bundle.name %>'} %}
+                <div id="{{ key }}-panel" class="kmcc-tabs__panel{% if key == node.internalName %} active{% endif %}">
+                    <% if not isV4 %>
+                        {% include '<%= bundle.name %>:Pages:LegalPage/_content.html.twig' with {'page': pageToRender} %}
+                    <% else %>
+                        {% include 'Pages/LegalPage/_content.html.twig' with {'page': pageToRender} %}
+                    <% endif %>
+                </div>
             {% endif %}
         {% endfor %}
     </div>

--- a/src/Resources/views/Components/TabBarContentPanel.html.twig
+++ b/src/Resources/views/Components/TabBarContentPanel.html.twig
@@ -1,7 +1,5 @@
+{% deprecated 'The "' ~ _self ~ '" template is deprecated since kunstmaanCookieBundle 1.4 and will be removed in kunstmaanAdminBundle 2.0. The content of this file is moved to the generated "Pages/LegalPage/pagetemplate.html.twig" twig file.' %}
+
 <div id="{{ key }}-panel" class="kmcc-tabs__panel{% if key == node.internalName %} active{% endif %}">
-    {% if not isV4 %}
-        {% include bundle~':Pages:LegalPage/_content.html.twig' with {'page': pageToRender} %}
-    {% else %}
-        {% include 'Pages/LegalPage/_content.html.twig' with {'page': pageToRender} %}
-    {% endif %}
+    {% include bundle~':Pages:LegalPage/_content.html.twig' with {'page': pageToRender} %}
 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | fixed #34 

I reverted the changes in `TabBarContentPanel.html.twig` and deprecated this template. The sf4 compatible code is moved to the skeleton files so the correct twig code is generated.